### PR TITLE
fix : 이메일을 기준으로 인증 코드 저장 및 조회, 토큰 발급

### DIFF
--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/MailService.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/MailService.java
@@ -25,7 +25,7 @@ public class MailService {
     private final VerificationCodeService verificationCodeService;
 
     @Transactional
-    public void sendVerificationCodeMail(Long shelterId, String email) {
+    public void sendVerificationCodeMail(String email) {
         MimeMessage message = javaMailSender.createMimeMessage();
         String code = RandomCodeGenerator.generate();
         try {
@@ -39,7 +39,7 @@ public class MailService {
             mimeMessageHelper.setText(htmlContent, true);
 
             javaMailSender.send(message);
-            verificationCodeService.create(shelterId, code);
+            verificationCodeService.create(email, code);
 
         } catch (MessagingException e) {
             throw new RuntimeException("메일 전송 실패", e);
@@ -47,8 +47,8 @@ public class MailService {
     }
 
     //TODO : 인증 코드 확인(boolean)
-    public boolean checkVerificationCode(Long shelterId, String code) {
-        VerificationCode originCode = verificationCodeService.checkCode(shelterId).orElseThrow(() -> new IllegalArgumentException("인증 코드를 다시 발급 받아 주세요."));
+    public boolean checkVerificationCode(String email, String code) {
+        VerificationCode originCode = verificationCodeService.checkCode(email).orElseThrow(() -> new IllegalArgumentException("인증 코드를 다시 발급 받아 주세요."));
         if (!originCode.getCode().equals(code)) {
             return false;
         }

--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/dto/request/ShelterLoginReq.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/dto/request/ShelterLoginReq.java
@@ -1,0 +1,19 @@
+package org.wildflowergardening.backend.api.wildflowergardening.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ShelterLoginReq {
+    @NotNull(message = "email이 null입니다.")
+    @Schema(description = "센터 id", example = "email@email.com")
+    private String email;
+
+    @NotEmpty(message = "센터 비밀번호가 비어있습니다.")
+    @Size(max = 255, message = "센터 비밀번호를 255자 이하로 입력해주세요.")
+    @Schema(description = "센터 password", example = "password_example")
+    private String pw;
+}

--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/dto/request/VerificationCodeRequest.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/dto/request/VerificationCodeRequest.java
@@ -1,4 +1,4 @@
-package org.wildflowergardening.backend.api.wildflowergardening.presentation.dto.request;
+package org.wildflowergardening.backend.api.wildflowergardening.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
@@ -8,9 +8,9 @@ import lombok.Getter;
 
 @Getter
 public class VerificationCodeRequest {
-    @NotNull(message = "센터 id가 null입니다.")
-    @Schema(description = "센터 id", example = "1")
-    private Long id;
+    @NotNull(message = "email이 null입니다.")
+    @Schema(description = "email", example = "1")
+    private String email;
 
     @NotEmpty(message = "인증 코드가 비었습니다.")
     @Size(max = 11, message = "인증 코드를 10자 이내로 입력해주세요.")

--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/presentation/ShelterAdminAppController.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/presentation/ShelterAdminAppController.java
@@ -43,15 +43,15 @@ import org.wildflowergardening.backend.api.wildflowergardening.application.auth.
 import org.wildflowergardening.backend.api.wildflowergardening.application.auth.interceptor.ShelterAdminAuthInterceptor;
 import org.wildflowergardening.backend.api.wildflowergardening.application.auth.user.ShelterUserContext;
 import org.wildflowergardening.backend.api.wildflowergardening.application.dto.*;
+import org.wildflowergardening.backend.api.wildflowergardening.application.dto.request.ShelterLoginReq;
 import org.wildflowergardening.backend.api.wildflowergardening.application.dto.response.EmergencyResponse;
 import org.wildflowergardening.backend.api.wildflowergardening.application.dto.response.HomelessDetailResponse;
 import org.wildflowergardening.backend.api.wildflowergardening.presentation.dto.ShelterInfoResponse;
 import org.wildflowergardening.backend.api.wildflowergardening.presentation.dto.UpdateChiefOfficerRequest;
-import org.wildflowergardening.backend.api.wildflowergardening.presentation.dto.request.VerificationCodeRequest;
+import org.wildflowergardening.backend.api.wildflowergardening.application.dto.request.VerificationCodeRequest;
 import org.wildflowergardening.backend.api.wildflowergardening.util.PhoneNumberFormatter;
 import org.wildflowergardening.backend.core.wildflowergardening.application.SleepoverExcelService;
 import org.wildflowergardening.backend.core.wildflowergardening.application.dto.BaseResponseBody;
-import org.wildflowergardening.backend.core.wildflowergardening.domain.Homeless;
 
 @RestController
 @RequiredArgsConstructor
@@ -74,7 +74,7 @@ public class ShelterAdminAppController {
 
     @PostMapping("/api/v1/shelter-admin/verification-code")
     @Operation(summary = "이메일로 인증 번호 전송")
-    public ResponseEntity<? extends BaseResponseBody> sendCode(@RequestBody @Valid ShelterLoginRequest request) {
+    public ResponseEntity<? extends BaseResponseBody> sendCode(@RequestBody @Valid ShelterLoginReq request) {
         shelterAdminAppService.sendCode(request);
         return ResponseEntity.ok().body(new BaseResponseBody<>(200, "메일 전송 성공"));
     }

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/kernel/application/exception/WildflowerExceptionType.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/kernel/application/exception/WildflowerExceptionType.java
@@ -5,27 +5,27 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum WildflowerExceptionType implements ExceptionType {
-  SHELTER_ADMIN_LOGIN_ID_PASSWORD_INVALID("센터 ID 또는 Password 가 올바르지 않습니다."),
-  SHELTER_ADMIN_LOGIN_CODE_INVALID("이메일 인증 코드가 유효하지 않습니다"),
-  SHELTER_ADMIN_CHIEF_OFFICERS_TOO_MANY("책임자 수가 많아서 더이상 생성할 수 없습니다."),
-  SHELTER_ADMIN_CHIEF_OFFICER_PHONE_NUMBER_ALREADY_EXISTS("해당 전화번호로 책임자 정보가 이미 존재합니다."),
-  SHELTER_ADMIN_CHIEF_OFFICER_NOT_FOUND("책임자 정보가 존재하지 않습니다."),
-  HOMELESS_APP_CREATE_ACCOUNT_SHELTER_ID_PIN_INVALID("센터 ID 또는 PIN 번호가 올바르지 않습니다."),
-  HOMELESS_APP_ESSENTIAL_TERMS_NOT_AGREED("필수 약관이 동의되지 않았습니다."),
-  HOMELESS_APP_NOT_DATA_LOCATION("위치 정보가 존재하지 않습니다."),
-  WILDFLOWER_ADMIN_AUTHENTICATION_FAILED("들꽃지기 관리자 인증에 실패했습니다."),
-  HOMELESS_APP_CREATE_DEFAULT_LOCATION("기본 위치 상태 생성 실패");
-  ;
+    SHELTER_ADMIN_LOGIN_ID_PASSWORD_INVALID("센터 ID 또는 Password 가 올바르지 않습니다."),
+    SHELTER_ADMIN_LOGIN_EMAIL_INVALID("등록되지 않은 email입니다"),
+    SHELTER_ADMIN_LOGIN_CODE_INVALID("이메일 인증 코드가 유효하지 않습니다"),
+    SHELTER_ADMIN_CHIEF_OFFICERS_TOO_MANY("책임자 수가 많아서 더이상 생성할 수 없습니다."),
+    SHELTER_ADMIN_CHIEF_OFFICER_PHONE_NUMBER_ALREADY_EXISTS("해당 전화번호로 책임자 정보가 이미 존재합니다."),
+    SHELTER_ADMIN_CHIEF_OFFICER_NOT_FOUND("책임자 정보가 존재하지 않습니다."),
+    HOMELESS_APP_CREATE_ACCOUNT_SHELTER_ID_PIN_INVALID("센터 ID 또는 PIN 번호가 올바르지 않습니다."),
+    HOMELESS_APP_ESSENTIAL_TERMS_NOT_AGREED("필수 약관이 동의되지 않았습니다."),
+    HOMELESS_APP_NOT_DATA_LOCATION("위치 정보가 존재하지 않습니다."),
+    WILDFLOWER_ADMIN_AUTHENTICATION_FAILED("들꽃지기 관리자 인증에 실패했습니다."),
+    HOMELESS_APP_CREATE_DEFAULT_LOCATION("기본 위치 상태 생성 실패");;
 
-  private final String message;
+    private final String message;
 
-  @Override
-  public String code() {
-    return this.name();
-  }
+    @Override
+    public String code() {
+        return this.name();
+    }
 
-  @Override
-  public String message() {
-    return this.message;
-  }
+    @Override
+    public String message() {
+        return this.message;
+    }
 }

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/application/ShelterService.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/application/ShelterService.java
@@ -2,6 +2,7 @@ package org.wildflowergardening.backend.core.wildflowergardening.application;
 
 import java.util.List;
 import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,34 +13,39 @@ import org.wildflowergardening.backend.core.wildflowergardening.domain.ShelterRe
 @Service
 public class ShelterService {
 
-  private final ShelterRepository shelterRepository;
+    private final ShelterRepository shelterRepository;
 
-  @Transactional
-  public Long save(Shelter shelter) {
-    boolean isAlreadyExist = shelterRepository.findByName(shelter.getName())
-        .isPresent();
-    if (isAlreadyExist) {
-      throw new IllegalArgumentException("이름이 " + shelter.getName() + "인 센터가 이미 존재합니다.");
+    @Transactional
+    public Long save(Shelter shelter) {
+        boolean isAlreadyExist = shelterRepository.findByName(shelter.getName())
+                .isPresent();
+        if (isAlreadyExist) {
+            throw new IllegalArgumentException("이름이 " + shelter.getName() + "인 센터가 이미 존재합니다.");
+        }
+        return shelterRepository.save(shelter).getId();
     }
-    return shelterRepository.save(shelter).getId();
-  }
 
-  @Transactional(readOnly = true)
-  public List<Shelter> getAll() {
-    return shelterRepository.findAll();
-  }
+    @Transactional(readOnly = true)
+    public List<Shelter> getAll() {
+        return shelterRepository.findAll();
+    }
 
-  /**
-   * @return 인증 성공 시 인증한 센터, 실패 시 null
-   */
-  @Transactional(readOnly = true)
-  public Optional<Shelter> getShelterById(Long id) {
-    return shelterRepository.findById(id);
-  }
+    /**
+     * @return 인증 성공 시 인증한 센터, 실패 시 null
+     */
+    @Transactional(readOnly = true)
+    public Optional<Shelter> getShelterById(Long id) {
+        return shelterRepository.findById(id);
+    }
 
-  @Transactional
-  public void changePassword(Long shelterId, String newPwEncrypted) {
-    shelterRepository.findById(shelterId)
-        .ifPresent(shelter -> shelter.setPassword(newPwEncrypted));
-  }
+    @Transactional(readOnly = true)
+    public Optional<Shelter> getShelterByEmail(String email) {
+        return shelterRepository.findByEmail(email);
+    }
+
+    @Transactional
+    public void changePassword(Long shelterId, String newPwEncrypted) {
+        shelterRepository.findById(shelterId)
+                .ifPresent(shelter -> shelter.setPassword(newPwEncrypted));
+    }
 }

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/application/VerificationCodeService.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/application/VerificationCodeService.java
@@ -7,7 +7,6 @@ import org.wildflowergardening.backend.core.wildflowergardening.domain.Verificat
 import org.wildflowergardening.backend.core.wildflowergardening.domain.VerificationCodeRepository;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Optional;
 
 @Service
@@ -18,10 +17,10 @@ public class VerificationCodeService {
 
     //TODO: 인증 코드 생성하기
     @Transactional
-    public Long create(Long shelterId, String code) {
+    public Long create(String email, String code) {
         LocalDateTime curTime = LocalDateTime.now();
         VerificationCode verificationCode = VerificationCode.builder()
-                .shelterId(shelterId)
+                .email(email)
                 .code(code)
                 .expiredAt(curTime.plusMinutes(VALIDATION_TIME))
                 .build();
@@ -30,9 +29,9 @@ public class VerificationCodeService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<VerificationCode> checkCode(long shelterId) {
+    public Optional<VerificationCode> checkCode(String email) {
         LocalDateTime curTime = LocalDateTime.now();
-        return verificationCodeRepository.findFirstValidCodeByShelterId(shelterId, curTime);
+        return verificationCodeRepository.findFirstValidCodeByEmail(email, curTime);
     }
 
 }

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/ShelterRepository.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/ShelterRepository.java
@@ -1,8 +1,11 @@
 package org.wildflowergardening.backend.core.wildflowergardening.domain;
 
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShelterRepository extends JpaRepository<Shelter, Long> {
-  Optional<Shelter> findByName(String name);
+    Optional<Shelter> findByName(String name);
+
+    Optional<Shelter> findByEmail(String email);
 }

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/VerificationCode.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/VerificationCode.java
@@ -22,9 +22,9 @@ public class VerificationCode {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "shelter_id")
-    @Comment("보호소 ID")
-    private Long shelterId;
+    @Column(name = "email")
+    @Comment("인증 번호를 받은 이메일")
+    private String email;
 
     @Column(name = "expired_at", nullable = false)
     @Comment("만료 시간")

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/VerificationCodeRepository.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/VerificationCodeRepository.java
@@ -10,13 +10,13 @@ import java.util.Optional;
 public interface VerificationCodeRepository extends JpaRepository<VerificationCode, Long> {
     // TODO : sheterID를 기반으로 code가져오기 그런데 마감 기한이 현재 날짜보다 긴 것으로 그리고 사용되지 않은 것으로 그리고 최근 생성된 순으로
     @Query("SELECT v FROM VerificationCode v " +
-            "WHERE v.shelterId = :shelterId " +
+            "WHERE v.email = :email " +
             "AND v.expiredAt > :currentDate " +
             "AND v.isUsed = false " +
             "ORDER BY v.createdAt DESC " +
             "limit 1")
-    Optional<VerificationCode> findFirstValidCodeByShelterId(
-            @Param("shelterId") Long shelterId,
+    Optional<VerificationCode> findFirstValidCodeByEmail(
+            @Param("email") String email,
             @Param("currentDate") LocalDateTime currentDate
     );
 


### PR DESCRIPTION
- (기존) 인증 코드 발급/확인을 위해 shelterId 사용 -> (변경) email 사용
- (기존) shelterId를 활용하여 토큰 발급 -> (변경) email을 활용하여 shelterId조회 후 이를 활용해 토큰 발급