### PR TITLE
[BE] 공지사항 발송 내역 및 이력 API

### DIFF
--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/HomelessAppService.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/HomelessAppService.java
@@ -342,7 +342,7 @@ public class HomelessAppService {
                             .title(notice.getTitle())
                             .contents(notice.getContents())
                             .sendAt(notice.getCreatedAt())
-                            .isRead(recipient.isRead())
+                            .isRead(recipient.getIsRead())
                             .build();
                 })
                 .collect(Collectors.groupingBy(

--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/ShelterAdminAppService.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/ShelterAdminAppService.java
@@ -381,4 +381,24 @@ public class ShelterAdminAppService {
         return NoticeRecipientStatusResponse.builder().items(items).noticeReadInfo(NoticeRecipientStatusResponse.NoticeReadInfo.builder().totalCount(totalCount).readCount(readCount).unReadCount(unReadCount).build()).build();
     }
 
+    public NoticeItemResponse getOneNotice(Long noticeId, Long shelterId) {
+        Notice notice = noticeService.getOneByIdAndShelterId(noticeId, shelterId).orElseThrow(() -> new IllegalArgumentException("해당 id를 가진 공지사항이 없습니다."));
+        NoticeItemResponse response = NoticeItemResponse.builder()
+                .noticeId(notice.getId())
+                .title(notice.getTitle())
+                .contents(notice.getContents())
+                .createdAt(notice.getCreatedAt())
+                .imageUrl(notice.getImageUrl())
+                .isSurvey(notice.getIsSurvey())
+                .tags(List.of("전체인원", "미확인인원", "미참여인원"))
+                .readHomelessIds(noticeRecipientService.getHomelessIdsByNoticeIdAndReadStatus(noticeId, true))
+                .unreadHomelessIds(noticeRecipientService.getHomelessIdsByNoticeIdAndReadStatus(noticeId, false))
+                .notParticipateHomelessIds(noticeRecipientService.getHomelessIdsByNoticeIdAndParticipateStatus(noticeId, ParticipateStatus.NOT_PARTICIPATE))
+                .build();
+
+        return response;
+
+    }
+
+
 }

--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/dto/response/NoticeItemResponse.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/dto/response/NoticeItemResponse.java
@@ -5,11 +5,11 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
-public class NoticeResponse {
-
+public class NoticeItemResponse {
     private Long noticeId;
 
     @Schema(description = "제목", example = "공지사항 제목")
@@ -27,9 +27,15 @@ public class NoticeResponse {
     @Schema(description = "설문 유무", example = "false")
     private Boolean isSurvey;
 
-    @Schema(description = "읽은 사람의 수", example = "15")
-    private Long readCount;
+    @Schema(description = "태그", example = "[\"전체인원\", \"미확인인원\", \"미참여 인원\"]")
+    private List<String> tags;
 
-    @Schema(description = "전체 대상자 수", example = "30")
-    private Long totalCount;
+    @Schema(description = "읽은 사람의 id", example = "[\"1\", \"2\"]")
+    private List<Long> readHomelessIds;
+
+    @Schema(description = "안읽은 사람의 id", example = "[\"3\", \"4\"]")
+    private List<Long> unreadHomelessIds;
+
+    @Schema(description = "미참여 사람의 id", example = "[\"1\", \"2\"]")
+    private List<Long> notParticipateHomelessIds;
 }

--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/pager/NoticeNoFilterPager.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/application/pager/NoticeNoFilterPager.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import org.wildflowergardening.backend.api.wildflowergardening.application.dto.NumberPageResponse;
 import org.wildflowergardening.backend.api.wildflowergardening.application.dto.request.NoticePageRequest;
 import org.wildflowergardening.backend.api.wildflowergardening.application.dto.response.NoticeResponse;
+import org.wildflowergardening.backend.core.wildflowergardening.application.NoticeRecipientService;
 import org.wildflowergardening.backend.core.wildflowergardening.application.NoticeService;
 import org.wildflowergardening.backend.core.wildflowergardening.application.dto.NumberPageResult;
 import org.wildflowergardening.backend.api.wildflowergardening.application.dto.NumberPageResponse.PageInfoResponse;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 public class NoticeNoFilterPager implements NoticeFilterPager {
 
     private final NoticeService noticeService;
+    private final NoticeRecipientService noticeRecipientService;
 
     @Override
     public NumberPageResponse<NoticeResponse> getPage(NoticePageRequest pageRequest) {
@@ -28,10 +30,14 @@ public class NoticeNoFilterPager implements NoticeFilterPager {
                         result.getItems().stream()
                                 .sorted(Comparator.comparing(Notice::getCreatedAt).reversed())
                                 .map(notice -> NoticeResponse.builder()
-                                        .id(notice.getId())
+                                        .noticeId(notice.getId())
                                         .title(notice.getTitle())
                                         .contents(notice.getContents())
-                                        .sendAt(notice.getCreatedAt()).build())
+                                        .createdAt(notice.getCreatedAt())
+                                        .isSurvey(notice.getIsSurvey())
+                                        .readCount(noticeRecipientService.getCountByNoticeIdAndReadStatus(notice.getId(), true))
+                                        .totalCount(noticeRecipientService.getAllCountByNotice(notice.getId()))
+                                        .build())
                                 .collect(Collectors.toList())
                 )
                 .pagination(PageInfoResponse.of(result.getPagination()))

--- a/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/presentation/ShelterAdminAppController.java
+++ b/backend-api/src/main/java/org/wildflowergardening/backend/api/wildflowergardening/presentation/ShelterAdminAppController.java
@@ -547,7 +547,7 @@ public class ShelterAdminAppController {
             example = "session-token-example"
     ))
     @GetMapping("/api/v2/shelter-admin/notice")
-    @Operation(summary = "공지사항 목록 조회", description = "공지 사항 전체 조회")
+    @Operation(summary = "공지 사항 목록 조회", description = "공지 사항 전체 조회")
     public ResponseEntity<NumberPageResponse<NoticeResponse>> getNoticePage(
             @RequestParam(defaultValue = "1") @Parameter(description = "조회할 페이지 번호 (1부터 시작)", example = "1") int pageNumber,
             @RequestParam(defaultValue = "20") @Parameter(description = "페이지 당 조회할 item 갯수", example = "20") int pageSize
@@ -578,6 +578,22 @@ public class ShelterAdminAppController {
     ) {
         ShelterUserContext shelterContext = (ShelterUserContext) userContextHolder.getUserContext();
         NoticeRecipientStatusResponse response = shelterAdminAppService.getNoticeRecipientStatus(noticeId, shelterContext.getShelterId());
+        return ResponseEntity.ok(response);
+    }
+
+    @ShelterAuthorized
+    @Parameters(@Parameter(
+            name = ShelterAuthInterceptor.AUTH_HEADER_NAME,
+            in = ParameterIn.HEADER,
+            example = "session-token-example"
+    ))
+    @GetMapping("/api/v2/shelter-admin/notice/{noticeId}")
+    @Operation(summary = "공지 사항 조회", description = "noticeId를 가진 공지 사항 조회.")
+    public ResponseEntity<NoticeItemResponse> getOneNotice(
+            @PathVariable Long noticeId
+    ) {
+        ShelterUserContext shelterContext = (ShelterUserContext) userContextHolder.getUserContext();
+        NoticeItemResponse response = shelterAdminAppService.getOneNotice(noticeId, shelterContext.getShelterId());
         return ResponseEntity.ok(response);
     }
 

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/application/NoticeRecipientService.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/application/NoticeRecipientService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.wildflowergardening.backend.core.wildflowergardening.domain.NoticeRecipient;
 import org.wildflowergardening.backend.core.wildflowergardening.domain.NoticeRecipientRepository;
+import org.wildflowergardening.backend.core.wildflowergardening.domain.ParticipateStatus;
 import org.wildflowergardening.backend.core.wildflowergardening.domain.auth.Session;
 import org.wildflowergardening.backend.core.wildflowergardening.domain.auth.UserRole;
 import org.wildflowergardening.backend.core.wildflowergardening.domain.dto.NoticeRecipientReadDto;
@@ -29,7 +30,7 @@ public class NoticeRecipientService {
     public void updateReadStatus(Long noticeId, Long homelessId, boolean status) {
         List<NoticeRecipient> noticeRecipientList = noticeRecipientRepository.findByNoticeIdAndHomelessId(noticeId, homelessId);
         for (NoticeRecipient noticeRecipient : noticeRecipientList) {
-            noticeRecipient.setRead(status);
+            noticeRecipient.setIsRead(status);
             noticeRecipient.setReadAt(LocalDateTime.now());
         }
     }
@@ -60,6 +61,21 @@ public class NoticeRecipientService {
     @Transactional(readOnly = true)
     public Long getCountByNoticeIdAndReadStatus(Long noticeId, boolean readStatus) {
         return noticeRecipientRepository.findCountByNoticeIdAndReadStatus(noticeId, readStatus);
+    }
+
+    @Transactional(readOnly = true)
+    public Long getAllCountByNotice(Long noticeId) {
+        return noticeRecipientRepository.findAllCountByNoticeId(noticeId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getHomelessIdsByNoticeIdAndReadStatus(Long noticeId, boolean readStatus) {
+        return noticeRecipientRepository.findHomelessIdByNoticeIdAndReadStatus(noticeId, readStatus);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Long> getHomelessIdsByNoticeIdAndParticipateStatus(Long noticeId, ParticipateStatus status) {
+        return noticeRecipientRepository.findHomelessIdByNoticeIdAndParticipateStatus(noticeId, status);
     }
 }
 

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/application/NoticeService.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/application/NoticeService.java
@@ -47,7 +47,7 @@ public class NoticeService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<Notice> getOneById(Long id) {
-        return noticeRepository.findById(id);
+    public Optional<Notice> getOneByIdAndShelterId(Long noticeId, Long shelterId) {
+        return noticeRepository.findByIdAndShelterId(noticeId, shelterId);
     }
 }

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/NoticeRecipientRepository.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/NoticeRecipientRepository.java
@@ -35,4 +35,18 @@ public interface NoticeRecipientRepository extends JpaRepository<NoticeRecipient
             "WHERE nr.noticeId =:noticeId "
             + "AND nr.isRead = :isRead")
     Long findCountByNoticeIdAndReadStatus(@Param("noticeId") Long noticeId, @Param("isRead") boolean isRead);
+
+    @Query("SELECT count(*) from NoticeRecipient nr " +
+            "WHERE nr.noticeId =:noticeId")
+    Long findAllCountByNoticeId(@Param("noticeId") Long noticeId);
+
+    @Query("SELECT nr.homelessId FROM NoticeRecipient nr " +
+            "WHERE nr.noticeId=:noticeId "
+            + "AND nr.isRead = :isRead")
+    List<Long> findHomelessIdByNoticeIdAndReadStatus(@Param("noticeId") Long noticeId, @Param("isRead") boolean isRead);
+
+    @Query("SELECT nr.homelessId FROM NoticeRecipient nr " +
+            "WHERE nr.noticeId=:noticeId "
+            + "AND nr.participateStatus = :participateStatus")
+    List<Long> findHomelessIdByNoticeIdAndParticipateStatus(@Param("noticeId") Long noticeId, @Param("participateStatus") ParticipateStatus participateStatus);
 }

--- a/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/NoticeRepository.java
+++ b/backend-core/src/main/java/org/wildflowergardening/backend/core/wildflowergardening/domain/NoticeRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     Page<Notice> findByShelterId(Long shelterId, Pageable pageable);
 
     List<Notice> findByIdIn(List<Long> noticeIds);
+
+    Optional<Notice> findByIdAndShelterId(Long noticeId, Long shelterId);
 }


### PR DESCRIPTION
[공지사항 목록 조회] : GET /notices
[
  {
    "noticeId": "string",
    "title": "string",
    "content": "string",
    "createdAt": "datetime",
    "image": "string (optional)",
    "isSurvey": true,
    "readCount": 15, // 읽은 인원 수
    "totalCount": 30 // 전체 대상자 수
  },

[공지사항 상세보기] : GET /notices/{noticeId}
{
  "noticeId": "string",
  "title": "string",
  "content": "string",
  "createdAt": "datetime",
  "image": "string (optional)",
  "isSurvey": true,
  "tags": ["전체인원", "미확인인원", "미참여인원"],
  "readUsers": ["userId1", "userId2", ...],
  "notReadUsers": ["userId3", "userId4", ...],
  "notParticipatedUsers": ["userId5", "userId6", ...]
}